### PR TITLE
Just refinements

### DIFF
--- a/groups_by_attribute_type.py
+++ b/groups_by_attribute_type.py
@@ -39,6 +39,13 @@ if not h5py.is_hdf5(bag_path):
     raise RuntimeError("The passed BAG file is not recognized as a valid HDF5 format")
 logger.info("input BAG file: %s" % bag_path)
 
+# setup comparison parameters
+copyBaseBag = False;
+ziptype = None # To test with compression, set this to "gzip" or "lzf".
+test_suffix = "ATT"
+if ziptype != None:
+    test_suffix += "_" + ziptype
+
 # open the input BAG in reading mode (and check the presence of the BAG_root group)
 
 fid = h5py.File(bag_path, 'r')
@@ -51,7 +58,7 @@ logger.info("input BAG: open")
 # open the output BAG in writing mode
 
 bag_name = os.path.basename(bag_path)
-out_path = os.path.join(test_output_folder, os.path.splitext(bag_name)[0] + "_ATT" + os.path.splitext(bag_name)[1])
+out_path = os.path.join(test_output_folder, os.path.splitext(bag_name)[0] + "_" + test_suffix + os.path.splitext(bag_name)[1])
 logger.info("output BAG file: %s" % out_path)
 if os.path.exists(out_path):
     os.remove(out_path)
@@ -86,9 +93,11 @@ def clone_content_without_varres_items(key):
             logger.info("- %s: dataset attribute copy: %s -> %s" % (key, ka, kv))
         logger.info("- %s: dataset copy (%s)" % (key, fid[key].dtype))
 
-
-logger.info("cloning content (skipping varres* elements)")
-fid.visit(clone_content_without_varres_items)
+if copyBaseBag:
+    logger.info("cloning content (skipping varres* elements)")
+    fid.visit(clone_content_without_varres_items)
+else:
+    logger.info("skipping all source elements")
 
 #  create the BAG_tiles root-group to store the tiles for the corresponding super cells
 
@@ -231,11 +240,11 @@ def modify_varres_content(key):
         meta = fid[key]
         logger.info("- %s -> %s" % (key, meta.shape))
         group_counter = 0
-        fod.create_dataset(bag_tiles_group + "/res_x"   , meta.shape, dtype="float32")
-        fod.create_dataset(bag_tiles_group + "/res_y"   , meta.shape, dtype="float32")
-        fod.create_dataset(bag_tiles_group + "/west"    , meta.shape, dtype="float32")
-        fod.create_dataset(bag_tiles_group + "/south"   , meta.shape, dtype="float32")
-        fod.create_dataset(bag_tiles_group + "/group_id", meta.shape, dtype="int")
+        fod.create_dataset(bag_tiles_group + "/res_x"   , meta.shape, dtype="float32", compression=ziptype)
+        fod.create_dataset(bag_tiles_group + "/res_y"   , meta.shape, dtype="float32", compression=ziptype)
+        fod.create_dataset(bag_tiles_group + "/west"    , meta.shape, dtype="float32", compression=ziptype)
+        fod.create_dataset(bag_tiles_group + "/south"   , meta.shape, dtype="float32", compression=ziptype)
+        fod.create_dataset(bag_tiles_group + "/group_id", meta.shape, dtype="int", compression=ziptype)
         for r in range(meta.shape[0]):
             for c in range(meta.shape[1]):
                 if meta[r][c][-1] != -1:
@@ -278,20 +287,21 @@ def modify_varres_content(key):
             to = meta[0]
 
             tile_elevation = elevation_group + tile_id
-            fod.create_dataset(tile_elevation, (meta[2], meta[1]), dtype="float32")
+            fod.create_dataset(tile_elevation, (meta[2], meta[1]), dtype="float32", compression=ziptype)
             for tr in range(meta[2]):
                 for tc in range(meta[1]):
                     fod[tile_elevation][tr, tc] = refs[to + tr * meta[2] + tc][0]
 
             if trk.shape[0] != 0:
                 tile_tracking_list = tracking_group + tile_id
-                fod.create_dataset(tile_tracking_list, (0, 0),
-                                   dtype={'names': ['row', 'col', 'depth', 'uncertainty', 'track_code', 'list_series'],
+                fod.create_dataset( tile_tracking_list, (0, 0),
+                                    dtype={'names': ['row', 'col', 'depth', 'uncertainty', 'track_code', 'list_series'],
                                           'formats': ['<u4', '<u4', '<f4', '<f4', 'u1', '<i2'],
-                                          'offsets': [0, 4, 8, 12, 16, 18], 'itemsize': 20})
+                                          'offsets': [0, 4, 8, 12, 16, 18], 'itemsize': 20},
+                                    compression=ziptype)
 
             tile_uncertainty = uncert_group + tile_id
-            fod.create_dataset(tile_uncertainty, (meta[2], meta[1]), dtype="float32")
+            fod.create_dataset(tile_uncertainty, (meta[2], meta[1]), dtype="float32", compression=ziptype)
             for tr in range(meta[2]):
                 for tc in range(meta[1]):
                     fod[tile_uncertainty][tr, tc] = refs[to + tr * meta[2] + tc][1]

--- a/tiles_with_compound_shape.py
+++ b/tiles_with_compound_shape.py
@@ -42,7 +42,7 @@ logger.info("input BAG file: %s" % bag_path)
 # setup comparison parameters
 copyBaseBag = False;
 ziptype = None # To test with compression, set this to "gzip" or "lzf".
-test_suffix = "CMP"
+test_suffix = "SHP"
 if ziptype != None:
     test_suffix += "_" + ziptype
 
@@ -233,6 +233,8 @@ def modify_varres_content(key):
     if "varres" not in key:
         logger.info("- %s: skip" % (key,))
         return
+        
+    numatts = 2 # Elevation, Uncertainty
 
     # retrieve and store the metadata relative to the VR refinements
     # + create a tile for each super cell with VR refinements
@@ -247,8 +249,8 @@ def modify_varres_content(key):
                     valid_tiles[(r, c)] = meta[r][c]
                     tile_id = bag_tiles_group + "/%d_%d" % (r, c)
                     tile_meta = meta[r][c]
-                    fod.create_dataset( tile_id, (tile_meta[2], tile_meta[1]), \
-                                        dtype=([('elevation', "float32"), ('uncertainty', "float32")]),
+                    fod.create_dataset( tile_id, (tile_meta[2], tile_meta[1], numatts),
+                                        dtype="float32",
                                         compression = ziptype)
                     fod[tile_id].attrs["res_x"] = tile_meta[3]
                     fod[tile_id].attrs["res_y"] = tile_meta[4]
@@ -279,7 +281,8 @@ def modify_varres_content(key):
             # Elevation and uncertainty are in the same order as in the original refinements list.
             for tr in range(meta[2]):
                 for tc in range(meta[1]):
-                    fod[tile_id][tr, tc] = refs[to + tr * meta[2] + tc]
+                    for ta in range(numatts):
+                        fod[tile_id][tr, tc, ta] = refs[to + tr * meta[2] + tc][ta]
 
             if trk.shape[0] != 0:
                 tile_tracking_list = tile_id + "_tracking_list" # Todo: Group this?


### PR DESCRIPTION
I've created another couple of scripts, and made some modifications to existing ones.  groups_by_attribute type, compound_tiles, groups_by_attribute_type_with_duplication, and tiles_with_compound_shape all have a couple of customizable constants:
copyBaseBag = False;
ziptype = None

Setting the former to True will re-enable the copying of BAG_root that I've disabled for compression testing.
Setting the latter to "gzip" or "lzf" will enable compression.

The two new scripts cover a few of the things that were discussed; duplicating tile metadata instead of having separate arrays, and using a third shape dimension in place of a compound datatype.  Discussions on filesize implications in Tuesday's meeting.